### PR TITLE
Rename RequestHandler to Action

### DIFF
--- a/proposed/http-message-strategies/http-message-strategies.md
+++ b/proposed/http-message-strategies/http-message-strategies.md
@@ -21,7 +21,7 @@ interfaces/functionality.
 * An _HTTP Message Strategy_ is a component which can be used to process HTTP messages.
 This specification defines contracts for the most common strategies, which accept a _PSR-7 Message_ and produce a _PSR-7 Message_.
 * An _Operator_ is a functional component which returns a result of the same type as its operand.
-* A _RequestHandler_ is a functional component which accepts a request and returns a `Psr\Http\Message\ResponseInterface` result.
+* A _Action_ is a functional component which accepts a request and returns a `Psr\Http\Message\ResponseInterface` result.
 
 ## 2. Package
 
@@ -54,7 +54,7 @@ interface RequestOperatorInterface
 }
 ```
 
-### 3.2 `Psr\Http\Message\Strategies\RequestHandlerInterface`
+### 3.2 `Psr\Http\Message\Strategies\ActionInterface`
 
 ```php
 namespace Psr\Http\Message\Strategies;
@@ -65,7 +65,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Defines a contract for functions which accept a request argument and produce a response.
  */
-interface RequestHandlerInterface
+interface ActionInterface
 {
     /**
      * Process a request and return the produced response.
@@ -101,7 +101,7 @@ interface ResponseOperatorInterface
 }
 ```
 
-### 3.4 `Psr\Http\Message\Strategies\ServerRequestHandlerInterface`
+### 3.4 `Psr\Http\Message\Strategies\ServerActionInterface`
 
 ```php
 namespace Psr\Http\Message\Strategies;
@@ -112,7 +112,7 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Defines a contract for functions which accept a server request argument and produce a respose.
  */
-interface ServerRequestHandlerInterface
+interface ServerActionInterface
 {
     /**
      * Process a server request and return the produced response.


### PR DESCRIPTION
I'm thinking about this for at least two month or so and I have written too many `IndexAction`/… classes  to ignore the name `Action`.

# Quick Comparisons

## [Action-Domain-Responder (ADR)](https://github.com/pmjones/adr)

[Example](https://github.com/pmjones/adr/blob/31198ecb800b11e13eb4ea64d296d20934f83d5f/example-code/Web/Blog/Action/BlogEditAction.php#L24-L29):

```php
class BlogEditAction
{
    protected $request;
    protected $domain;
    protected $responder;

    public function __construct(
        Request $request,
        BlogService $domain,
        BlogEditResponder $responder
    ) {
        $this->request = $request;
        $this->domain = $domain;
        $this->responder = $responder;
    }

    public function __invoke($id)
    {
        $payload = $this->domain->fetchPost($id);
        $this->responder->setPayload($payload);
        return $this->responder->__invoke(); // returns an Aura\Web\Response object
    }
}
```

### Similarities
* Actions are callables (`__invoke`).
* Returns a `Response` object.

### Differences
* An Action holds a reference to the request.
* Actions are invoked with domain parameters, e.g. `$id`


## [play Framework (Java)](https://www.playframework.com/documentation/2.5.x/ScalaActions)

> #### What is an Action?
> Most of the requests received by a Play application are handled by an Action.
> 
> A `play.api.mvc.Action` is basically a `(play.api.mvc.Request => play.api.mvc.Result)` function that handles a request and generates a result to be sent to the client.
> ```scala
> def echo = Action { request =>
>   Ok("Got request [" + request + "]")
> }
> ```

### Similarities
* Actions are functions/callables.
* Receives a `Request` object.
* Returns a response object (`Result`).

### Differences
* [TBD] I'm not sufficiently qualified to answer that.

# Summary

I've also found [Action Methods in ASP.NET ](https://msdn.microsoft.com/en-us/library/dd410269(v=vs.98).aspx) and the HTML action attribute (`<form action="URL">`). IMO, the latter justifies the name `FrontControllerAction`.