### PR TITLE
Reduce scope (drop client strategies)

### DIFF
--- a/proposed/http-message-strategies/http-message-strategies-meta.md
+++ b/proposed/http-message-strategies/http-message-strategies-meta.md
@@ -36,12 +36,15 @@ concrete frameworks and vice versa.
 
 ### 3.1. Goals
 
-* Standardize common HTTP Message strategies to process HTTP Messages defined by [PSR-7](http://www.php-fig.org/psr/psr-7/).
+* Standardize common server-side HTTP Message strategies to process HTTP Messages defined by [PSR-7](http://www.php-fig.org/psr/psr-7/).
 * Standardize contracts based on best practices.
 
 ### 3.2. Non-Goals
 
 * Standardize or favor any particular application architecture or assume its presence.
+* Standardize asynchronous/client HTTP Message strategies, because
+  - there are not enough use cases known to the authors,
+  - these strategies can be standardized by separate PSRs.
 
 ## 4. Design Decisions
 

--- a/proposed/http-message-strategies/http-message-strategies.md
+++ b/proposed/http-message-strategies/http-message-strategies.md
@@ -31,54 +31,7 @@ The interfaces described are provided as part of the [psr/http-message-strategie
 
 An _HTTP Message Strategy_ using this standard MUST implement the corresponding `interface` and the behaviour described by its comments.
 
-### 3.1 `Psr\Http\Message\Strategies\RequestOperatorInterface`
-
-```php
-namespace Psr\Http\Message\Strategies;
-
-use Psr\Http\Message\RequestInterface;
-
-/**
- * Defines a contract for functions which accept a request argument and produce a request.
- */
-interface RequestOperatorInterface
-{
-    /**
-     * Process a request and return the produced request.
-     *
-     * @param RequestInterface $request
-     *
-     * @return RequestInterface
-     */
-    public function __invoke(RequestInterface $request);
-}
-```
-
-### 3.2 `Psr\Http\Message\Strategies\ActionInterface`
-
-```php
-namespace Psr\Http\Message\Strategies;
-
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-
-/**
- * Defines a contract for functions which accept a request argument and produce a response.
- */
-interface ActionInterface
-{
-    /**
-     * Process a request and return the produced response.
-     *
-     * @param RequestInterface $request
-     *
-     * @return ResponseInterface
-     */
-    public function __invoke(RequestInterface $request);
-}
-```
-
-### 3.3 `Psr\Http\Message\Strategies\ResponseOperatorInterface`
+### 3.1 `Psr\Http\Message\Strategies\ResponseOperatorInterface`
 
 ```php
 namespace Psr\Http\Message\Strategies;
@@ -101,7 +54,7 @@ interface ResponseOperatorInterface
 }
 ```
 
-### 3.4 `Psr\Http\Message\Strategies\ServerActionInterface`
+### 3.2 `Psr\Http\Message\Strategies\ServerActionInterface`
 
 ```php
 namespace Psr\Http\Message\Strategies;
@@ -125,7 +78,7 @@ interface ServerActionInterface
 }
 ```
 
-### 3.5 `Psr\Http\Message\Strategies\ServerRequestOperatorInterface`
+### 3.3 `Psr\Http\Message\Strategies\ServerRequestOperatorInterface`
 
 ```php
 namespace Psr\Http\Message\Strategies;


### PR DESCRIPTION
I believe my reasons are slightly different than the ones @mindplay-dk brought up at #6. I write them up here to retain them for further reference.

I have encountered only one use case for those interfaces over the last two months: building a [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy):

```php
$app = new \Slim\App;
$app->any('/{_:.*}', new Proxy(new Uri('http://httpbin.org')));
$app->run();
```

My idea was to use [guzzle-get](https://github.com/http-message-strategies-interop/example-guzzle-get) for that and it works well, but:
1. it is easy to workaround that (using an adapter etc.)
2. in PHP 7.2, workarounds will become even easier (parameter widening)
3. maybe one day PHP becomes smart enough, so we do not need to workaround this at all

But the decisive reason to me to drop the client stuff: clients and servers live in different [bounded contexts](https://en.wikipedia.org/wiki/Domain-driven_design#Bounded_context), e.g. `Request` means different things for clients and servers, and they do different things with it – building/sending/async vs. receiving/processing/sync. Thus, using a wrapper class to use a client library in a server environment is the most natural thing in the world.

Therefore, I believe standardizing client strategies in a separate PSR is just natural.

**Note:** I've [forked middleware/proxy](https://github.com/http-message-strategies-interop/proxy) today, another non-middleware example, which shows the usefulness of `[Server]Request -> Response`.